### PR TITLE
Feat: Add custom messaging support

### DIFF
--- a/lib/match.js
+++ b/lib/match.js
@@ -45,9 +45,11 @@ module.exports = {
       const [regex, regexStr] = getRegex(context.options[0], basename);
       if (!regex) return;
       if (!regex.test(basename)) {
+        const messageKey = context.options[1] ? 'message' : 'messageId';
+        const messageValue = context.options[1] || 'noMatch';
         context.report({
           node,
-          messageId: 'noMatch',
+          [messageKey]: messageValue,
           data: {
             name: basename,
             value: regexStr,

--- a/test/lib/match.test.js
+++ b/test/lib/match.test.js
@@ -328,3 +328,23 @@ test('file extension mapping', testRule({
     },
   ],
 }));
+
+test('custom message', testRule({
+  valid: [
+    {
+      code,
+      filename: '/foo/bar/test.txt',
+      options: [/^test(?:\..*)?$/],
+    },
+  ],
+  invalid: [
+    {
+      code,
+      filename: '/foo/bar/test_.txt',
+      options: [/^test(?:\..*)?$/, 'These are not he regex droids you are looking for'],
+      errors: [
+        { message: 'These are not he regex droids you are looking for', column: 1, line: 1 },
+      ],
+    },
+  ],
+}));


### PR DESCRIPTION
This PR adds custom messaging as an option. It will default to the messaging defined in the metadata.

To add a custom message, the user just needs to add another element to the array for his/her message:
```javascript
...
'filename-rules/match': [2, /^([a-z]+-)*[a-z]+(?:\..*)?$/], 'Custom message',
...
```