### PR TITLE
New Rule: not-match

### DIFF
--- a/lib/common/aliases.js
+++ b/lib/common/aliases.js
@@ -1,0 +1,11 @@
+const aliases = {
+  pascalcase: /^[A-Z]([A-Z0-9]*[a-z]+)+[A-Z0-9]*(?:\..*)?$/,
+  camelcase: /^[a-z]+((\d)|([A-Z0-9][a-z0-9]+))*([A-Z])?(?:\..*)?$/,
+  snakecase: /^([a-z]+_)*[a-z]+(?:\..*)?$/,
+  kebabcase: /^([a-z]+-)*[a-z]+(?:\..*)?$/,
+};
+exports.aliases = aliases;
+aliases.PascalCase = aliases.pascalcase;
+aliases.camelCase = aliases.camelcase;
+aliases.snake_case = aliases.snakecase;
+aliases['kebab-case'] = aliases.kebabcase;

--- a/lib/common/aliases.js
+++ b/lib/common/aliases.js
@@ -4,8 +4,9 @@ const aliases = {
   snakecase: /^([a-z]+_)*[a-z]+(?:\..*)?$/,
   kebabcase: /^([a-z]+-)*[a-z]+(?:\..*)?$/,
 };
-exports.aliases = aliases;
 aliases.PascalCase = aliases.pascalcase;
 aliases.camelCase = aliases.camelcase;
 aliases.snake_case = aliases.snakecase;
 aliases['kebab-case'] = aliases.kebabcase;
+
+exports.aliases = aliases;

--- a/lib/common/aliases.js
+++ b/lib/common/aliases.js
@@ -4,6 +4,7 @@ const aliases = {
   snakecase: /^([a-z]+_)*[a-z]+(?:\..*)?$/,
   kebabcase: /^([a-z]+-)*[a-z]+(?:\..*)?$/,
 };
+
 aliases.PascalCase = aliases.pascalcase;
 aliases.camelCase = aliases.camelcase;
 aliases.snake_case = aliases.snakecase;

--- a/lib/common/getRegex.js
+++ b/lib/common/getRegex.js
@@ -1,0 +1,15 @@
+const { aliases } = require('./aliases');
+
+const getRegex = (value, filename) => {
+  if (value instanceof RegExp) { return [value, value.toString()]; }
+  if (typeof value === 'string') {
+    const regex = aliases[value];
+    if (!regex) { throw new Error(`Unrecognized option "${value}"`); }
+    return [regex, value];
+  }
+
+  const extension = filename.substr(filename.lastIndexOf('.'));
+  const valueForExtension = value[extension];
+  return valueForExtension ? getRegex(valueForExtension) : [];
+};
+exports.getRegex = getRegex;

--- a/lib/common/getRegex.js
+++ b/lib/common/getRegex.js
@@ -18,6 +18,8 @@ const getRegex = (value, filename) => {
     throw new Error(`Unrecognized option "${value}"`);
   }
 
+  if (value.pattern) return getRegex(value.pattern, filename);
+
   const extension = filename.substr(filename.lastIndexOf('.'));
   const valueForExtension = value[extension];
   return valueForExtension ? getRegex(valueForExtension) : [];

--- a/lib/common/getRegex.js
+++ b/lib/common/getRegex.js
@@ -1,17 +1,26 @@
 const { aliases } = require('./aliases');
 
 const getRegex = (value, filename) => {
-  if (value instanceof RegExp) { return [value, value.toString()]; }
-  if (typeof value === 'string') {
-    const regex = aliases[value];
-    if (!regex) { throw new Error(`Unrecognized option "${value}"`); }
-    return [regex, value];
-  }
+  if (value instanceof RegExp) return [value, value.toString()];
 
-  if (value.pattern) return getRegex(value.pattern, filename);
+  if (typeof value === 'string') {
+    const predefinedRegex = aliases[value];
+    if (predefinedRegex) return [predefinedRegex, value];
+
+    if (value[0] === '/') {
+      const ix = value.lastIndexOf('/');
+      if (ix > 0) {
+        const regex = new RegExp(value.substring(1, ix - 1), value.substring(ix + 1));
+        return [regex, value];
+      }
+    }
+
+    throw new Error(`Unrecognized option "${value}"`);
+  }
 
   const extension = filename.substr(filename.lastIndexOf('.'));
   const valueForExtension = value[extension];
   return valueForExtension ? getRegex(valueForExtension) : [];
 };
+
 exports.getRegex = getRegex;

--- a/lib/common/getRegex.js
+++ b/lib/common/getRegex.js
@@ -8,6 +8,8 @@ const getRegex = (value, filename) => {
     return [regex, value];
   }
 
+  if (value.pattern) return getRegex(value.pattern, filename);
+
   const extension = filename.substr(filename.lastIndexOf('.'));
   const valueForExtension = value[extension];
   return valueForExtension ? getRegex(valueForExtension) : [];

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,9 @@
 const match = require('./match');
+const notMatch = require('./notMatch');
 
 module.exports = {
   rules: {
     match,
+    'not-match': notMatch,
   },
 };

--- a/lib/match.js
+++ b/lib/match.js
@@ -17,7 +17,7 @@ module.exports = {
   create: (context) => ({
     Program: (node) => {
       const filename = context.getFilename();
-      const includePath = !!((context.options[0] || {}).includePath);
+      const includePath = !!context.options[0]?.includePath;
       const name = includePath ? filename : path.basename(filename);
       const [regex, regexStr] = getRegex(context.options[0], name);
       if (!regex) return;

--- a/lib/match.js
+++ b/lib/match.js
@@ -17,15 +17,16 @@ module.exports = {
   create: (context) => ({
     Program: (node) => {
       const filename = context.getFilename();
-      const basename = path.basename(filename);
-      const [regex, regexStr] = getRegex(context.options[0], basename);
+      const includePath = !!((context.options[0] || {}).includePath);
+      const name = includePath ? filename : path.basename(filename);
+      const [regex, regexStr] = getRegex(context.options[0], name);
       if (!regex) return;
-      if (!regex.test(basename)) {
+      if (!regex.test(name)) {
         context.report({
           node,
           messageId: 'noMatch',
           data: {
-            name: basename,
+            name,
             value: regexStr,
           },
         });

--- a/lib/notMatch.js
+++ b/lib/notMatch.js
@@ -4,7 +4,7 @@ const { getRegex } = require('./common/getRegex');
 const meta = {
   type: 'layout',
   docs: {
-    description: 'checks that filenames does not match a chosen pattern',
+    description: 'checks that filenames do not match a chosen pattern',
   },
   fixable: false,
   messages: {

--- a/lib/notMatch.js
+++ b/lib/notMatch.js
@@ -17,7 +17,7 @@ module.exports = {
   create: (context) => ({
     Program: (node) => {
       const filename = context.getFilename();
-      const includePath = !!((context.options[0] || {}).includePath);
+      const includePath = !!(context.options[0] || {}).includePath;
       const name = includePath ? filename : path.basename(filename);
       const [regex, regexStr] = getRegex(context.options[0], name);
       if (!regex) return;

--- a/lib/notMatch.js
+++ b/lib/notMatch.js
@@ -4,11 +4,11 @@ const { getRegex } = require('./common/getRegex');
 const meta = {
   type: 'layout',
   docs: {
-    description: 'checks that filenames match a chosen pattern',
+    description: 'checks that filenames does not match a chosen pattern',
   },
   fixable: false,
   messages: {
-    noMatch: "Filename '{{name}}' does not match {{value}}.",
+    match: "Filename '{{name}}' must not match {{value}}.",
   },
 };
 
@@ -20,10 +20,10 @@ module.exports = {
       const basename = path.basename(filename);
       const [regex, regexStr] = getRegex(context.options[0], basename);
       if (!regex) return;
-      if (!regex.test(basename)) {
+      if (regex.test(basename)) {
         context.report({
           node,
-          messageId: 'noMatch',
+          messageId: 'match',
           data: {
             name: basename,
             value: regexStr,

--- a/lib/notMatch.js
+++ b/lib/notMatch.js
@@ -17,15 +17,16 @@ module.exports = {
   create: (context) => ({
     Program: (node) => {
       const filename = context.getFilename();
-      const basename = path.basename(filename);
-      const [regex, regexStr] = getRegex(context.options[0], basename);
+      const includePath = !!((context.options[0] || {}).includePath);
+      const name = includePath ? filename : path.basename(filename);
+      const [regex, regexStr] = getRegex(context.options[0], name);
       if (!regex) return;
-      if (regex.test(basename)) {
+      if (regex.test(name)) {
         context.report({
           node,
           messageId: 'match',
           data: {
-            name: basename,
+            name,
             value: regexStr,
           },
         });

--- a/test/lib/index.test.js
+++ b/test/lib/index.test.js
@@ -2,7 +2,12 @@ import test from 'ava';
 
 import * as lib from '../../lib/index';
 import match from '../../lib/match';
+import notMatch from '../../lib/notMatch';
 
 test('exports the match rule', (t) => {
   t.is(lib.rules.match, match);
+});
+
+test('exports the notMatch rule', (t) => {
+  t.is(lib.rules['not-match'], notMatch);
 });

--- a/test/lib/match.test.js
+++ b/test/lib/match.test.js
@@ -27,6 +27,32 @@ test('single regex', testRule({
   ],
 }));
 
+test('includePath', testRule({
+  valid: [
+    {
+      code,
+      filename: '/foo/bar/test.txt',
+      options: [{
+        pattern: /^.*bar.*$/,
+        includePath: true,
+      }],
+    },
+  ],
+  invalid: [
+    {
+      code,
+      filename: '/foo/bar/test.txt',
+      options: [{
+        pattern: /^.*baz.*$/,
+        includePath: true,
+      }],
+      errors: [
+        { message: "Filename '/foo/bar/test.txt' does not match /^.*baz.*$/.", column: 1, line: 1 },
+      ],
+    },
+  ],
+}));
+
 test('throws on unknown alias', (t) => t.throws(testRule({
   valid: [
     {

--- a/test/lib/notMatch.test.js
+++ b/test/lib/notMatch.test.js
@@ -27,6 +27,32 @@ test('single regex', testRule({
   ],
 }));
 
+test('includePath', testRule({
+  invalid: [
+    {
+      code,
+      filename: '/foo/bar/test.txt',
+      options: [{
+        pattern: /^.*bar.*$/,
+        includePath: true,
+      }],
+      errors: [
+        { message: "Filename '/foo/bar/test.txt' must not match /^.*bar.*$/.", column: 1, line: 1 },
+      ],
+    },
+  ],
+  valid: [
+    {
+      code,
+      filename: '/foo/bar/test.txt',
+      options: [{
+        pattern: /^.*baz.*$/,
+        includePath: true,
+      }],
+    },
+  ],
+}));
+
 test('throws on unknown alias', (t) => t.throws(testRule({
   valid: [
     {

--- a/test/lib/notMatch.test.js
+++ b/test/lib/notMatch.test.js
@@ -1,0 +1,312 @@
+import test from 'ava';
+import { RuleTester } from 'eslint';
+
+import * as notMatch from '../../lib/notMatch';
+
+const tester = new RuleTester();
+const testRule = (tests) => () => tester.run('not-match', notMatch, tests);
+const code = '"hello world";';
+
+test('single regex', testRule({
+  invalid: [
+    {
+      code,
+      filename: '/foo/bar/test.txt',
+      options: [/^test(?:\..*)?$/],
+      errors: [
+        { message: "Filename 'test.txt' must not match /^test(?:\\..*)?$/.", column: 1, line: 1 },
+      ],
+    },
+  ],
+  valid: [
+    {
+      code,
+      filename: '/foo/bar/test_.txt',
+      options: [/^test(?:\..*)?$/],
+    },
+  ],
+}));
+
+test('throws on unknown alias', (t) => t.throws(testRule({
+  valid: [
+    {
+      code,
+      filename: '/foo/bar/module.js',
+      options: ['bla'],
+    },
+  ],
+  invalid: [],
+}), 'Unrecognized option "bla"\nOccurred while linting /foo/bar/module.js:1'));
+
+['camelcase', 'camelCase'].forEach((alias) => {
+  test(`single alias - ${alias}`, testRule({
+    invalid: [
+      {
+        code,
+        filename: '/foo/bar/module.js',
+        options: [alias],
+        errors: [
+          { message: `Filename 'module.js' must not match ${alias}.`, column: 1, line: 1 },
+        ],
+      },
+      {
+        code,
+        filename: '/foo/bar/anotherModule.js',
+        options: [alias],
+        errors: [
+          { message: `Filename 'anotherModule.js' must not match ${alias}.`, column: 1, line: 1 },
+        ],
+      },
+      {
+        code,
+        filename: '/foo/bar/module.test.js',
+        options: [alias],
+        errors: [
+          { message: `Filename 'module.test.js' must not match ${alias}.`, column: 1, line: 1 },
+        ],
+      },
+    ],
+    valid: [
+      {
+        code,
+        filename: '/foo/bar/Module.js',
+        options: [alias],
+      },
+      {
+        code,
+        filename: '/foo/bar/AnotherModule.js',
+        options: [alias],
+      },
+      {
+        code,
+        filename: '/foo/bar/another-module.js',
+        options: [alias],
+      },
+      {
+        code,
+        filename: '/foo/bar/another_module.js',
+        options: [alias],
+      },
+    ],
+  }));
+});
+
+['pascalcase', 'PascalCase'].forEach((alias) => {
+  test(`single alias - ${alias}`, testRule({
+    invalid: [
+      {
+        code,
+        filename: '/foo/bar/Url.js',
+        options: [alias],
+        errors: [
+          { message: `Filename 'Url.js' must not match ${alias}.`, column: 1, line: 1 },
+        ],
+      },
+      {
+        code,
+        filename: '/foo/bar/AnotherModule.js',
+        options: [alias],
+        errors: [
+          { message: `Filename 'AnotherModule.js' must not match ${alias}.`, column: 1, line: 1 },
+        ],
+      },
+      {
+        code,
+        filename: '/foo/bar/AnotherModule.test.js',
+        options: [alias],
+        errors: [
+          { message: `Filename 'AnotherModule.test.js' must not match ${alias}.`, column: 1, line: 1 },
+        ],
+      },
+      {
+        code,
+        filename: '/foo/bar/ModuleNameWithACRONYM.js',
+        options: [alias],
+        errors: [
+          { message: `Filename 'ModuleNameWithACRONYM.js' must not match ${alias}.`, column: 1, line: 1 },
+        ],
+      },
+    ],
+    valid: [
+      {
+        code,
+        filename: '/foo/bar/URL.js',
+        options: [alias],
+      },
+      {
+        code,
+        filename: '/foo/bar/url.js',
+        options: [alias],
+      },
+      {
+        code,
+        filename: '/foo/bar/anotherModule.js',
+        options: [alias],
+      },
+      {
+        code,
+        filename: '/foo/bar/Another-Module.js',
+        options: [alias],
+      },
+      {
+        code,
+        filename: '/foo/bar/Another_Module.js',
+        options: [alias],
+      },
+    ],
+  }));
+});
+
+['snakecase', 'snake_case'].forEach((alias) => {
+  test(`single alias - ${alias}`, testRule({
+    invalid: [
+      {
+        code,
+        filename: '/foo/bar/module.js',
+        options: [alias],
+        errors: [
+          { message: `Filename 'module.js' must not match ${alias}.`, column: 1, line: 1 },
+        ],
+      },
+      {
+        code,
+        filename: '/foo/bar/another_module.js',
+        options: [alias],
+        errors: [
+          { message: `Filename 'another_module.js' must not match ${alias}.`, column: 1, line: 1 },
+        ],
+      },
+      {
+        code,
+        filename: '/foo/bar/another_module.test.js',
+        options: [alias],
+        errors: [
+          { message: `Filename 'another_module.test.js' must not match ${alias}.`, column: 1, line: 1 },
+        ],
+      },
+    ],
+    valid: [
+      {
+        code,
+        filename: '/foo/bar/Module.js',
+        options: [alias],
+      },
+      {
+        code,
+        filename: '/foo/bar/AnotherModule.js',
+        options: [alias],
+      },
+      {
+        code,
+        filename: '/foo/bar/anotherModule.js',
+        options: [alias],
+      },
+      {
+        code,
+        filename: '/foo/bar/another-module.js',
+        options: [alias],
+      },
+      {
+        code,
+        filename: '/foo/bar/Another_Module.js',
+        options: [alias],
+      },
+    ],
+  }));
+});
+
+['kebabcase', 'kebab-case'].forEach((alias) => {
+  test(`single alias - ${alias}`, testRule({
+    invalid: [
+      {
+        code,
+        filename: '/foo/bar/module.js',
+        options: [alias],
+        errors: [
+          { message: `Filename 'module.js' must not match ${alias}.`, column: 1, line: 1 },
+        ],
+      },
+      {
+        code,
+        filename: '/foo/bar/another-module.js',
+        options: [alias],
+        errors: [
+          { message: `Filename 'another-module.js' must not match ${alias}.`, column: 1, line: 1 },
+        ],
+      },
+      {
+        code,
+        filename: '/foo/bar/another-module.test.js',
+        options: [alias],
+        errors: [
+          { message: `Filename 'another-module.test.js' must not match ${alias}.`, column: 1, line: 1 },
+        ],
+      },
+    ],
+    valid: [
+      {
+        code,
+        filename: '/foo/bar/Module.js',
+        options: [alias],
+      },
+      {
+        code,
+        filename: '/foo/bar/AnotherModule.js',
+        options: [alias],
+      },
+      {
+        code,
+        filename: '/foo/bar/anotherModule.js',
+        options: [alias],
+      },
+      {
+        code,
+        filename: '/foo/bar/Another-Module.js',
+        options: [alias],
+      },
+      {
+        code,
+        filename: '/foo/bar/another_module.js',
+        options: [alias],
+      },
+    ],
+  }));
+});
+
+test('file extension mapping', testRule({
+  invalid: [
+    {
+      code,
+      filename: '/foo/bar/someModule.js',
+      options: [{ '.js': 'camelcase', '.ts': /^([a-z]+-)*[a-z]+(?:\..*)?$/ }],
+      errors: [
+        { message: "Filename 'someModule.js' must not match camelcase.", column: 1, line: 1 },
+      ],
+    },
+    {
+      code,
+      filename: '/foo/bar/some-module.ts',
+      options: [{ '.js': 'camelcase', '.ts': /^([a-z]+-)*[a-z]+(?:\..*)?$/ }],
+      errors: [
+        { message: "Filename 'some-module.ts' must not match /^([a-z]+-)*[a-z]+(?:\\..*)?$/.", column: 1, line: 1 },
+      ],
+    },
+  ],
+  valid: [
+    {
+      code,
+      filename: '/foo/bar/some-module.js',
+      options: [{ '.js': 'camelcase', '.ts': /^([a-z]+-)*[a-z]+(?:\..*)?$/ }],
+    },
+    {
+      code,
+      filename: '/foo/bar/someModule.ts',
+      options: [{ '.js': 'camelcase', '.ts': /^([a-z]+-)*[a-z]+(?:\..*)?$/ }],
+    },
+    {
+      code,
+      filename: '/foo/bar/SkippedModule.jsx',
+      options: [{ '.js': 'camelcase', '.ts': /^([a-z]+-)*[a-z]+(?:\..*)?$/ }],
+    },
+  ],
+}));


### PR DESCRIPTION
Solves #13

I also added an option `includePath: <boolean>` to support full-path matching (as opposed to just the file basename). I needed this because I realized that `AdBanner` was actually the name of a module, and so the path of the file was `whatever/AdBanner/index.tsx`. If you would prefer I split that into another PR I could do it that way. LMK