### PR TITLE
fix: substring-ing the right regex

### DIFF
--- a/lib/common/getRegex.js
+++ b/lib/common/getRegex.js
@@ -10,7 +10,7 @@ const getRegex = (value, filename) => {
     if (value[0] === '/') {
       const ix = value.lastIndexOf('/');
       if (ix > 0) {
-        const regex = new RegExp(value.substring(1, ix - 1), value.substring(ix + 1));
+        const regex = new RegExp(value.substring(1, ix), value.substring(ix + 1));
         return [regex, value];
       }
     }

--- a/test/lib/match.test.js
+++ b/test/lib/match.test.js
@@ -14,6 +14,11 @@ test('single regex', testRule({
       filename: '/foo/bar/test.txt',
       options: [/^test(?:\..*)?$/],
     },
+    {
+      code,
+      filename: '/foo/bar/test.txt',
+      options: ['/^test(?:\\..*)/'],
+    },
   ],
   invalid: [
     {


### PR DESCRIPTION
<img src="https://media0.giphy.com/media/8nhgZZMKUicpi/giphy.gif"/>

I was fooled in #11 by the current unit testing, but we are removing the last character of the regex which make it break if fx the last character is a `)` that indicates the end of a group.