### PR TITLE
added schema description of a rule’s options

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Adds an ESLint rule to enforce filename conventions for linted files. Allows dif
 ```bash
 $ npm install -D eslint-plugin-filename-rules
 ```
-
+## Old style config
 Add it to your `.eslintrc.js`:
 
 ```js
@@ -26,6 +26,21 @@ module.exports = {
     'filename-rules/match': [2, 'camelcase'],
   },
 };
+```
+
+## Flat config
+
+```js
+import fileName from 'eslint-plugin-filename-rules'
+
+{
+  plugins: {
+    'filename-rules': fileName,
+  },
+  rules: {
+    'filename-rules/match': [2, 'camelcase']
+  }
+}
 ```
 
 ## Plugin Options

--- a/lib/common/aliases.js
+++ b/lib/common/aliases.js
@@ -11,3 +11,13 @@ aliases.snake_case = aliases.snakecase;
 aliases['kebab-case'] = aliases.kebabcase;
 
 exports.aliases = aliases;
+exports.aliasesNames = [
+  'pascalcase',
+  'PascalCase',
+  'camelcase',
+  'camelCase',
+  'kebabcase',
+  'kebab-case',
+  'snakecase',
+  'snake_case',
+];

--- a/lib/match.js
+++ b/lib/match.js
@@ -1,14 +1,32 @@
 const path = require('path');
 const { getRegex } = require('./common/getRegex');
+const { aliasesNames } = require('./common/aliases');
 
 const meta = {
   type: 'layout',
+  name: 'match',
   docs: {
     description: 'checks that filenames match a chosen pattern',
   },
   fixable: false,
   messages: {
     noMatch: "Filename '{{name}}' does not match {{value}}.",
+  },
+  schema: {
+    type: 'array',
+    minItems: 1,
+    maxItems: 2,
+    oneOf: [
+      {
+        items: [{ type: 'string', enum: aliasesNames }],
+      },
+      {
+        items: [{ type: 'string', pattern: '/.*./' }],
+      },
+      {
+        items: [{ type: 'object' }],
+      },
+    ],
   },
 };
 

--- a/lib/notMatch.js
+++ b/lib/notMatch.js
@@ -1,14 +1,32 @@
 const path = require('path');
 const { getRegex } = require('./common/getRegex');
+const { aliasesNames} = require('./common/aliases');
 
 const meta = {
   type: 'layout',
+  name: 'not-match',
   docs: {
     description: 'checks that filenames do not match a chosen pattern',
   },
   fixable: false,
   messages: {
     match: "Filename '{{name}}' must not match {{value}}.",
+  },
+  schema: {
+    type: 'array',
+    minItems: 1,
+    maxItems: 2,
+    oneOf: [
+      {
+        items: [{ type: 'string', enum: aliasesNames }],
+      },
+      {
+        items: [{ type: 'string', pattern: '/.*./' }],
+      },
+      {
+        items: [{ type: 'object' }],
+      },
+    ],
   },
 };
 


### PR DESCRIPTION
There was no way to use this plugin without schema with eslint flat config. 